### PR TITLE
bugfix added missing dropoff key in BlastData

### DIFF
--- a/src/module/item/SR5Item.ts
+++ b/src/module/item/SR5Item.ts
@@ -381,7 +381,7 @@ export class SR5Item extends Item {
             const dropoff = ammo.data.data.blast.dropoff;
             return {
                 radius: distance,
-                dropoff,
+                dropoff: dropoff,
             };
         }
     }


### PR DESCRIPTION
It looks like getBlastData() function is not returning a proper BlastData object in the final if else statement because of a missing key name.  I noticed this in passing, but did not see or test for a specific error in the application. Thanks for all the hard work on this project!